### PR TITLE
add atomic settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It's written to be fast, work in any browser and have no dependencies at all.
 
 It simply loops over all the characters using a single function call, storing the
 last location of an allowed break point, if any. Otherwise it just truncates the string
-or return empty string if `atomic` options set up to `true` (in some cases its just better).
+or return empty string if `truncate` options set up to `false` (in some cases its just better).
 
 ## Examples
 
@@ -55,16 +55,16 @@ You may provide an alternative ellipse character, or "break points" like so:
 
 ```
 
-Also you may provide a setting to `atomic` words:
+Also you may provide a setting to `truncate` words:
 
 ```javascript
     var ellipsize = require('ellipsize');
 
-    ellipsize( '123456789ABCDEF', 8, { atomic: true });
+    ellipsize( '123456789ABCDEF', 8, { truncate: false });
     // '' 
 
     // its default settings
-    ellipsize( '123456789ABCDEF', 8, { atomic: false });
+    ellipsize( '123456789ABCDEF', 8, { truncate: true });
     // '1234567…'
 
 ```

--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@ var defaults = {
     ellipse: '…',
     chars: [' ', '-'],
     max: 140,
-    atomic: false
+    truncate: true
 };
 
-function ellipsize(str, max, ellipse, chars, atomic) {
+function ellipsize(str, max, ellipse, chars, truncate) {
     var last = 0,
         c = '';
 
@@ -22,7 +22,7 @@ function ellipsize(str, max, ellipse, chars, atomic) {
 
         if (i < max) continue;
         if (last === 0) {
-            return atomic ? '' : str.substring(0, max - 1) + ellipse;
+            return !truncate ? '' : str.substring(0, max - 1) + ellipse;
         }
 
         return str.substring(0, last) + ellipse;
@@ -38,10 +38,12 @@ module.exports = function(str, max, opts) {
     opts = opts || {};
 
     for (var key in defaults) {
-        opts[key] = opts[key] || defaults[key];
+        if (opts[key] === null || typeof opts[key] === 'undefined') {
+            opts[key] = defaults[key];
+        }
     }
 
     opts.max = max || opts.max;
 
-    return ellipsize(str, opts.max, opts.ellipse, opts.chars, opts.atomic);
+    return ellipsize(str, opts.max, opts.ellipse, opts.chars, opts.truncate);
 };

--- a/test/index.js
+++ b/test/index.js
@@ -71,34 +71,41 @@ suite('ellipsize', function() {
         });
     });
 
-    test('ellipsize atomic settings', function() {
+    test('ellipsize truncate settings', function() {
         var cases = [
             {
-                label: 'atomic settings on',
+                label: 'truncate settings off',
                 len: 8,
                 string: '123456789ABCDEF',
                 expect: '',
-                atomic: true
+                truncate: false
             },
             {
-                label: 'atomic settings off',
+                label: 'truncate settings on',
                 len: 8,
                 string: '123456789ABCDEF',
                 expect: '1234567' + ELLIPSE,
-                atomic: false
+                truncate: true
             },
             {
-                label: 'atomic settings default',
+                label: 'truncate settings default',
                 len: 8,
                 string: '123456789ABCDEF',
                 expect: '1234567' + ELLIPSE,
-                atomic: undefined
+                truncate: undefined
+            },
+            {
+                label: 'truncate settings default',
+                len: 8,
+                string: '123456789ABCDEF',
+                expect: '1234567' + ELLIPSE,
+                truncate: null
             }
         ];
 
         cases.forEach(function(testCase) {
             var result = ellipsize(testCase.string, testCase.len, {
-                atomic: testCase.atomic
+                truncate: testCase.truncate
             });
             assert.equal(result, testCase.expect);
         });


### PR DESCRIPTION
In some cases we are prefer have empty string instead of part of word with ellipsize, especially in Russian.

So, I just add `atomic` option to have more correctly behaviour.

3in1 price, with code and docs. 
