### PR TITLE
middle truncation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.js]
+indent_size = 4

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "node": true,
+  },
+  "rules": {
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *komodoproject
 node_modules
+*.sw[a-z]

--- a/index.js
+++ b/index.js
@@ -12,20 +12,25 @@ function ellipsize(str, max, ellipse, chars, truncate) {
 
     var last = 0,
         c = '',
-        midMax = Math.floor((max - ellipse.length) / 2),
+        midMax = Math.floor(max / 2),
         computedMax = truncate === 'middle' ? midMax : max;
 
     for (var i = 0, len = str.length; i < len; i++) {
         c = str.charAt(i);
 
-        if (chars.indexOf(c) !== -1) {
+        if (chars.indexOf(c) !== -1 && truncate !== 'middle') {
             last = i;
         }
 
-
-        if (i + ellipse.length < computedMax) continue;
+        if (i < computedMax) continue;
         if (last === 0) {
-            return !truncate ? '' : str.substring(0, computedMax - 1) + ellipse + (truncate === 'middle' ? str.substring(str.length - midMax, str.length) : '');
+            return !truncate ? 
+                '' : 
+                str.substring(0, computedMax - 1) + ellipse + (
+                    truncate === 'middle' ? 
+                    str.substring(str.length - midMax, str.length) : 
+                    ''
+                );
         }
 
         return str.substring(0, last) + ellipse;

--- a/index.js
+++ b/index.js
@@ -8,10 +8,12 @@ var defaults = {
 };
 
 function ellipsize(str, max, ellipse, chars, truncate) {
-    var last = 0,
-        c = '';
-
     if (str.length < max) return str;
+
+    var last = 0,
+        c = '',
+        midMax = Math.floor((max - ellipse.length) / 2),
+        computedMax = truncate === 'middle' ? midMax : max;
 
     for (var i = 0, len = str.length; i < len; i++) {
         c = str.charAt(i);
@@ -20,9 +22,10 @@ function ellipsize(str, max, ellipse, chars, truncate) {
             last = i;
         }
 
-        if (i < max) continue;
+
+        if (i + ellipse.length < computedMax) continue;
         if (last === 0) {
-            return !truncate ? '' : str.substring(0, max - 1) + ellipse;
+            return !truncate ? '' : str.substring(0, computedMax - 1) + ellipse + (truncate === 'middle' ? str.substring(str.length - midMax, str.length) : '');
         }
 
         return str.substring(0, last) + ellipse;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ellipsize",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "Ellipsizes a string at the nearest whitespace character near the end of allowed length",
     "main": "index.js",
     "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -100,6 +100,13 @@ suite('ellipsize', function() {
                 string: '123456789ABCDEF',
                 expect: '1234567' + ELLIPSE,
                 truncate: null
+            },
+            {
+                label: 'truncate settings middle',
+                len: 8,
+                string: '123456789ABCDEF',
+                expect: '123' + ELLIPSE + 'CDEF',
+                truncate: 'middle'
             }
         ];
 
@@ -112,4 +119,52 @@ suite('ellipsize', function() {
 
     });
 
+    test('ellipsize truncate words', function() {
+        var cases = [
+            // XXX I'm unsure what the expected behavior should actually be, here
+            // {
+            //     label: 'truncate words settings off',
+            //     len: 12,
+            //     string: 'the quick brown fox',
+            //     expect: '',
+            //     truncate: false
+            // },
+            {
+                label: 'truncate words settings on',
+                len: 16,
+                string: 'the quick brown box',
+                expect: 'the quick brown' + ELLIPSE,
+                truncate: true
+            },
+            {
+                label: 'truncate words settings default',
+                len: 16,
+                string: 'the quick brown fox',
+                expect: 'the quick brown' + ELLIPSE,
+                truncate: undefined
+            },
+            {
+                label: 'truncate word settings default',
+                len: 16,
+                string: 'the quick brown fox',
+                expect: 'the quick brown' + ELLIPSE,
+                truncate: null
+            },
+            {
+                label: 'truncate words settings middle',
+                len: 16,
+                string: 'the quick brown fox',
+                expect: 'the qui' + ELLIPSE + 'rown fox',
+                truncate: 'middle'
+            }
+        ];
+
+        cases.forEach(function(testCase) {
+            var result = ellipsize(testCase.string, testCase.len, {
+                truncate: testCase.truncate
+            });
+            assert.equal(result, testCase.expect);
+        });
+
+    });
 });


### PR DESCRIPTION
Adds `truncate: 'middle'` setting to allow for mac-style mid-string ellipsization.