### PR TITLE
Mark opts argument as optional in JSDoc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ function ellipsize(str, max, ellipse, chars, truncate) {
  *
  * @param {string} str - String to ellipsize
  * @param {number} max - Max length including ellipsis
- * @param {Record<string, any>} opts - See additional options
+ * @param {Record<string, any>} [opts] - See additional options
  * @returns {string} ellipsized string
  */
 module.exports = function (str, max, opts) {


### PR DESCRIPTION
The JSDoc comment did not mark the opts argument as optional, thereby failing in any project that uses TypeScript to check JS-files (where the JS is typechecked by using hints from JSDoc comments) and does not provide the last argument.

See: https://jsdoc.app/tags-param.html#optional-parameters-and-default-values