### PR TITLE
Fix truncation disabled issue for some strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,15 +62,19 @@ function ellipsize(str, max, ellipse, chars, truncate) {
 
     var maxLen = max - ellipse.length;
     var end = maxLen;
+    var breakpointFound = false;
 
     for (var i = 0; i <= maxLen; i++) {
         var char = str.charAt(i);
-        if (chars.indexOf(char) !== -1) end = i;
+        if (chars.indexOf(char) !== -1) {
+            end = i;
+            breakpointFound = true;
+        }
     }
 
     // no breakpoint found, but truncate
     // was not allowed.
-    if (!truncate && end == maxLen) return "";
+    if (!truncate && !breakpointFound) return "";
 
     return str.slice(0, end) + ellipse;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -105,6 +105,13 @@ test("ellipsize truncate settings", function (assert) {
             truncate: true,
         },
         {
+            label: "truncate settings on and breakpoint at max length position",
+            len: 4,
+            string: "123 456",
+            expect: "123" + ELLIPSE,
+            truncate: false,
+        },
+        {
             label: "truncate settings default",
             len: 8,
             string: "123456789ABCDEF",


### PR DESCRIPTION
Fixes an issue where an empty string is returned if truncation is disabled and there happens to be a breakpoint character at the point in the original string that corresponds to the max length given

https://github.com/mvhenten/ellipsize/issues/11