### PR TITLE
chore: flip master to main

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
Despite the age of this package, it’s time to move away from non-inclusive branch naming conventions.